### PR TITLE
Write out ContractAssertionUtils as a separate file

### DIFF
--- a/NetDoc/Call.cs
+++ b/NetDoc/Call.cs
@@ -6,7 +6,7 @@ using Mono.Cecil.Cil;
 
 namespace NetDoc
 {
-    internal class Call
+    public class Call
     {
         private readonly MemberReference m_Operand;
 

--- a/NetDoc/ContractClassWriter.cs
+++ b/NetDoc/ContractClassWriter.cs
@@ -31,5 +31,18 @@ namespace NetDoc
             "Binding",
             "Command",
         };
+
+        public string UtilsSource => @"// ReSharper disable UnusedMember.Local
+// ReSharper disable InconsistentNaming
+// ReSharper disable once UnusedType.Global
+
+internal static class ContractAssertionUtils
+{
+    internal static T Create<T>() => default;
+    internal static void CheckReturnType<T>(T param) {}
+}
+
+internal class Ref<T> { public T Any = default; }
+";
     }
 }

--- a/NetDoc/ContractClassWriter.cs
+++ b/NetDoc/ContractClassWriter.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace NetDoc
 {
-    internal class ContractClassWriter
+    public class ContractClassWriter
     {
         public IEnumerable<string> ProcessCalls(string consumerName, IEnumerable<Call> calls)
         {

--- a/NetDoc/ContractClassWriter.cs
+++ b/NetDoc/ContractClassWriter.cs
@@ -44,5 +44,15 @@ internal static class ContractAssertionUtils
 
 internal class Ref<T> { public T Any = default; }
 ";
+
+        public string Header(string referencingClassName) => $@"using static ContractAssertionUtils;
+// ReSharper disable RedundantTypeArgumentsOfMethod
+// ReSharper disable once CheckNamespace
+internal abstract class {referencingClassName}ContractAssertions
+{{
+";
+
+        public string Footer => @"}";
+
     }
 }

--- a/NetDoc/FileNameOnlyComparer.cs
+++ b/NetDoc/FileNameOnlyComparer.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NetDoc
+{
+    internal class FileNameOnlyComparer : IEqualityComparer<string?>
+    {
+        public bool Equals(string? left, string? right)
+        {
+            if (left == null) return right == null;
+            return Path.GetFileName(left).Equals(Path.GetFileName(right), StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(string? obj)
+        {
+            return Path.GetFileName(obj)?.GetHashCode() ?? -1;
+        }
+    }
+}

--- a/NetDoc/Program.cs
+++ b/NetDoc/Program.cs
@@ -117,18 +117,4 @@ namespace NetDoc
                 .Distinct(new FileNameOnlyComparer());
         }
     }
-
-    internal class FileNameOnlyComparer : IEqualityComparer<string?>
-    {
-        public bool Equals(string? left, string? right)
-        {
-            if (left == null) return right == null;
-            return Path.GetFileName(left).Equals(Path.GetFileName(right), StringComparison.OrdinalIgnoreCase);
-        }
-
-        public int GetHashCode(string? obj)
-        {
-            return Path.GetFileName(obj)?.GetHashCode() ?? -1;
-        }
-    }
 }

--- a/NetDoc/Program.cs
+++ b/NetDoc/Program.cs
@@ -67,12 +67,7 @@ namespace NetDoc
         {
             var contract = new ContractClassWriter();
 
-            writer.Write($@"using static ContractAssertionUtils;
-// ReSharper disable RedundantTypeArgumentsOfMethod
-// ReSharper disable once CheckNamespace
-internal abstract class {referencing}ContractAssertions
-{{
-");
+            writer.Write(contract.Header(referencing));
             using var resolver = new DefaultAssemblyResolver();
             foreach (var r in referenced)
             {
@@ -96,7 +91,7 @@ internal abstract class {referencing}ContractAssertions
                 }
             }
 
-            writer.Write(@"}");
+            writer.Write(contract.Footer);
             writer.Flush();
 
             foreach (var ad in assemblyDefinitions)

--- a/NetDoc/Program.cs
+++ b/NetDoc/Program.cs
@@ -35,6 +35,9 @@ namespace NetDoc
                 return;
             }
 
+            var utilsFile = Path.Combine(assertionsOut, "ContractAssertionUtils.cs");
+            File.WriteAllText(utilsFile, new ContractClassWriter().UtilsSource);
+
             foreach (var repoPath in consumers)
             {
                 var repoName = Path.GetFileName(repoPath).ToTitleCase();
@@ -64,17 +67,11 @@ namespace NetDoc
         {
             var contract = new ContractClassWriter();
 
-            writer.Write($@"// ReSharper disable UnusedMember.Local
+            writer.Write($@"using static ContractAssertionUtils;
 // ReSharper disable RedundantTypeArgumentsOfMethod
-// ReSharper disable InconsistentNaming
 // ReSharper disable once CheckNamespace
-// ReSharper disable once UnusedType.Global
 internal abstract class {referencing}ContractAssertions
 {{
-    protected abstract T Create<T>();
-    protected abstract void CheckReturnType<T>(T param);
-    private class Ref<T> {{ public T Any = default; }}
-
 ");
             using var resolver = new DefaultAssemblyResolver();
             foreach (var r in referenced)

--- a/Tests/TestFramework/TestMethods.cs
+++ b/Tests/TestFramework/TestMethods.cs
@@ -13,7 +13,7 @@ namespace Tests.TestFramework
             using var writer = new StringWriter();
             Program.CreateContractAssertions(writer, "", new[] {referencedDll}, new[] {referencingDll});
             Console.WriteLine(writer.ToString());
-            ClrAssemblyCompiler.CompileDlls(writer.ToString(), referenced);
+            ClrAssemblyCompiler.CompileDlls(writer + new ContractClassWriter().UtilsSource, referenced);
             StringAssert.Contains("private void UsedByTestAssembly()", writer.ToString(),
                 "We should have created a method to contain the assertions for this assembly");
         }


### PR DESCRIPTION
Until now, every assertion class has had some boilerplate at the top (`Create<T>`, `CheckReturnType<T>`, class `Ref<T>`).  These were confusing and cluttered up the assertion classes, so I've extracted them into a Utils class instead.