### PR TITLE
New feature: Ignored assertions

### DIFF
--- a/NetDoc/ContractClassWriter.cs
+++ b/NetDoc/ContractClassWriter.cs
@@ -5,7 +5,7 @@ using Mono.Cecil;
 
 namespace NetDoc
 {
-    public class ContractClassWriter
+    public static class ContractClassWriter
     {
         public static void CreateContractAssertions(TextWriter writer, string referencing, IEnumerable<string> referenced, IEnumerable<string> assemblies)
         {
@@ -72,7 +72,7 @@ namespace NetDoc
             "Command",
         };
 
-        public string UtilsSource => @"// ReSharper disable UnusedMember.Local
+        public static string UtilsSource => @"// ReSharper disable UnusedMember.Local
 // ReSharper disable InconsistentNaming
 // ReSharper disable once UnusedType.Global
 

--- a/NetDoc/IgnorancePreserver.cs
+++ b/NetDoc/IgnorancePreserver.cs
@@ -7,6 +7,18 @@ namespace NetDoc
     {
         public const string AssertionSuppressor = "//IGNORE ";
 
+        /// <summary>
+        /// If a contract assertion already exists and contains ignored lines (defined by the <see cref="AssertionSuppressor"/>)
+        /// this method will modify a newly generated contract assertion to also ignore those lines.
+        /// </summary>
+        /// <remarks>
+        /// This feature is designed to account for tardy consumers, which have not taken the latest version of your library
+        /// but might do so eventually.
+        /// The ignored assertion will be removed when the consumer pulls in the breaking change.
+        /// </remarks>
+        /// <param name="oldContractAssertion">The contents of the old C# contract assertion</param>
+        /// <param name="newlyGeneratedAssertions">The contents of the newly generated C# contract assertion</param>
+        /// <param name="writer">Where to output the resulting contract assertion</param>
         public static void PreserveIgnoredAssertions(string oldContractAssertion, string newlyGeneratedAssertions, TextWriter writer)
         {
             var commented = oldContractAssertion.Split("\n")

--- a/NetDoc/IgnorancePreserver.cs
+++ b/NetDoc/IgnorancePreserver.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace NetDoc
+{
+    public class IgnorancePreserver
+    {
+        public const string AssertionSuppressor = "//IGNORE ";
+
+        public static void PreserveIgnoredAssertions(string oldContractAssertion, string newlyGeneratedAssertions, TextWriter writer)
+        {
+            var commented = oldContractAssertion.Split("\n")
+                .Where(s => s.Contains(AssertionSuppressor))
+                .ToDictionary(KeySelector);
+
+            foreach (var line in newlyGeneratedAssertions.Split("\n"))
+            {
+                var lineOrComment = commented.TryGetValue(KeySelector(line), out var commentedOutLine)
+                    ? commentedOutLine
+                    : line;
+                writer.WriteLine(lineOrComment.TrimEnd('\r'));
+            }
+        }
+
+        private static string KeySelector(string s)
+        {
+            return s.Replace(AssertionSuppressor, "").Trim('\r', '\t', ' ');
+        }
+    }
+}

--- a/NetDoc/Program.cs
+++ b/NetDoc/Program.cs
@@ -35,7 +35,7 @@ namespace NetDoc
             }
 
             var utilsFile = Path.Combine(assertionsOut, "ContractAssertionUtils.cs");
-            File.WriteAllText(utilsFile, new ContractClassWriter().UtilsSource);
+            File.WriteAllText(utilsFile, ContractClassWriter.UtilsSource);
 
             foreach (var repoPath in consumers)
             {

--- a/NetDoc/Program.cs
+++ b/NetDoc/Program.cs
@@ -46,9 +46,13 @@ namespace NetDoc
                 Console.WriteLine("Generating assertions for {0} assemblies in {1}...", assemblies.Count, repoName);
 
                 Directory.CreateDirectory(assertionsOut);
-                using var outFile = File.Open(Path.Combine(assertionsOut, $"{repoName}.cs"), FileMode.Create);
-                using var writer = new StreamWriter(outFile);
+                var assertionFileName = Path.Combine(assertionsOut, $"{repoName}.cs");
+                var oldContractAssertion = File.Exists(assertionFileName) ? File.ReadAllText(assertionFileName) : "";
+                using var outFile = File.Open(assertionFileName, FileMode.Create);
+                using var writer2 = new StreamWriter(outFile);
+                using var writer = new StringWriter();
                 CreateContractAssertions(writer, repoName, consumed, assemblies);
+                IgnorancePreserver.PreserveIgnoredAssertions(oldContractAssertion, writer.ToString(), writer2);
             }
         }
 

--- a/NetDoc/Program.cs
+++ b/NetDoc/Program.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Mono.Cecil;
 using rcx_parse_cli;
 
 namespace NetDoc
@@ -51,7 +50,7 @@ namespace NetDoc
                 using var outFile = File.Open(assertionFileName, FileMode.Create);
                 using var writer2 = new StreamWriter(outFile);
                 using var writer = new StringWriter();
-                CreateContractAssertions(writer, repoName, consumed, assemblies);
+                ContractClassWriter.CreateContractAssertions(writer, repoName, consumed, assemblies);
                 IgnorancePreserver.PreserveIgnoredAssertions(oldContractAssertion, writer.ToString(), writer2);
             }
         }
@@ -66,46 +65,6 @@ namespace NetDoc
             Console.WriteLine("    --outDir          Where to output the.cs files containing the contract");
             Console.WriteLine("                      assertions. This switch should only be used once.");
         }
-
-        public static void CreateContractAssertions(TextWriter writer, string referencing, IEnumerable<string> referenced, IEnumerable<string> assemblies)
-        {
-            var contract = new ContractClassWriter();
-
-            writer.Write(contract.Header(referencing));
-            using var resolver = new DefaultAssemblyResolver();
-            foreach (var r in referenced)
-            {
-                resolver.AddSearchDirectory(Path.GetDirectoryName(r));
-            }
-
-            var assemblyDefinitions = referenced.Select(AssemblyDefinition.ReadAssembly).ToList();
-            var referencedTypes = assemblyDefinitions.SelectMany(d => d.Modules).SelectMany(a => a.Types)
-                .Where(t => t.IsPublic)
-                .Select(x => $"{x.Namespace}::{x.Name}")
-                .Where(x => x != "::<Module>")
-                .ToHashSet();
-            foreach (var assembly in assemblies)
-            {
-                var calls = AssemblyAnalyser.AnalyseAssembly(assembly, resolver)
-                    .Where(call => TargetsReferencedAssembly(call, referencedTypes));
-                var assemblyName = Path.GetFileNameWithoutExtension(assembly).ToTitleCase();
-                foreach (var x in contract.ProcessCalls(assemblyName, calls))
-                {
-                    writer.WriteLine($"    {x}");
-                }
-            }
-
-            writer.Write(contract.Footer);
-            writer.Flush();
-
-            foreach (var ad in assemblyDefinitions)
-            {
-                ad.Dispose();
-            }
-        }
-
-        private static bool TargetsReferencedAssembly(Call arg, ICollection<string> candidateTypes) =>
-            candidateTypes.Contains(arg.ContainingTypeName);
 
         private static IEnumerable<string> AssembliesInFolder(string include, IEnumerable<string?> exclude)
         {

--- a/Tests/TardyConsumerTests.cs
+++ b/Tests/TardyConsumerTests.cs
@@ -35,7 +35,7 @@ namespace Tests
             IgnorancePreserver.PreserveIgnoredAssertions(oldContractAssertion, newlyGeneratedAssertions, writer2);
             Console.WriteLine("*** Commented out assertion:");
             Console.WriteLine(writer2.ToString());
-            ClrAssemblyCompiler.CompileDlls(writer2.ToString(), newReferenced);
+            ClrAssemblyCompiler.CompileDlls(writer2 + new ContractClassWriter().UtilsSource, newReferenced);
             StringAssert.Contains("private void UsedByTestAssembly()", writer2.ToString(),
                 "We should have created a method to contain the assertions for this assembly");
             return writer2.ToString();

--- a/Tests/TardyConsumerTests.cs
+++ b/Tests/TardyConsumerTests.cs
@@ -28,7 +28,7 @@ namespace Tests
         {
             var (oldReferencedDll, referencingDll) = ClrAssemblyCompiler.CompileDlls(referencing, oldReferenced);
             using var writer = new StringWriter();
-            Program.CreateContractAssertions(writer, "", new[] { oldReferencedDll }, new[] { referencingDll });
+            ContractClassWriter.CreateContractAssertions(writer, "", new[] { oldReferencedDll }, new[] { referencingDll });
             var newlyGeneratedAssertions = writer.ToString();
 
             using var writer2 = new StringWriter();

--- a/Tests/TardyConsumerTests.cs
+++ b/Tests/TardyConsumerTests.cs
@@ -35,7 +35,7 @@ namespace Tests
             IgnorancePreserver.PreserveIgnoredAssertions(oldContractAssertion, newlyGeneratedAssertions, writer2);
             Console.WriteLine("*** Commented out assertion:");
             Console.WriteLine(writer2.ToString());
-            ClrAssemblyCompiler.CompileDlls(writer2 + new ContractClassWriter().UtilsSource, newReferenced);
+            ClrAssemblyCompiler.CompileDlls(writer2 + ContractClassWriter.UtilsSource, newReferenced);
             StringAssert.Contains("private void UsedByTestAssembly()", writer2.ToString(),
                 "We should have created a method to contain the assertions for this assembly");
             return writer2.ToString();

--- a/Tests/TardyConsumerTests.cs
+++ b/Tests/TardyConsumerTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using NetDoc;
+using NUnit.Framework;
+using Tests.TestFramework;
+
+namespace Tests
+{
+    class TardyConsumerTests : TestMethods
+    {
+        private const string AssertionSuppressor = "//IGNORE ";
+
+        [Test]
+        public void PreviouslyIgnoredAssertionsRemainCommentedOut()
+        {
+            var oldReferenced = Class("public void OldMethod() {}", "Consumed");
+            var newReferenced = Class("public void NewMethod() {}", "Consumed");
+
+            var referencing = Class("public void CallsOldMethod() { new Consumed().OldMethod(); }");
+
+            var oldContractAssertion = ContractAssertionShouldCompile(referencing, oldReferenced);
+            //Assert.Throws<AssertionException>(() => ContractAssertionShouldCompile(referencing, newReferenced));
+            var commentedAssertion = oldContractAssertion.Replace("    Create", "    //IGNORE Create");
+
+            var newAssertion = UpdatedContractAssertionShouldCompile(referencing, oldReferenced, newReferenced, commentedAssertion);
+            StringAssert.Contains(AssertionSuppressor, newAssertion, "The new assertion should be commented out");
+        }
+
+        private string UpdatedContractAssertionShouldCompile(string referencing, string oldReferenced, string newReferenced, string oldContractAssertion)
+        {
+            var (oldReferencedDll, referencingDll) = ClrAssemblyCompiler.CompileDlls(referencing, oldReferenced);
+            using var writer = new StringWriter();
+            Program.CreateContractAssertions(writer, "", new[] { oldReferencedDll }, new[] { referencingDll });
+            var commented = oldContractAssertion.Split("\n")
+                .Where(s => s.Contains(AssertionSuppressor))
+                .ToDictionary(KeySelector);
+
+            using var writer2 = new StringWriter();
+            foreach (var line in writer.ToString().Split("\n"))
+            {
+                var lineOrComment = commented.TryGetValue(KeySelector(line), out var commentedOutLine)
+                    ? commentedOutLine
+                    : line;
+                writer2.WriteLine(lineOrComment.TrimEnd('\r'));
+            }
+            Console.WriteLine("*** Commented out assertion:");
+            Console.WriteLine(writer2.ToString());
+            ClrAssemblyCompiler.CompileDlls(writer2.ToString(), newReferenced);
+            StringAssert.Contains("private void UsedByTestAssembly()", writer2.ToString(),
+                "We should have created a method to contain the assertions for this assembly");
+            return writer2.ToString();
+        }
+
+        private static string KeySelector(string s)
+        {
+            return s.Replace(AssertionSuppressor, "").Trim('\r', '\t', ' ');
+        }
+    }
+}

--- a/Tests/TestFramework/TestMethods.cs
+++ b/Tests/TestFramework/TestMethods.cs
@@ -19,7 +19,7 @@ namespace Tests.TestFramework
             using var writer = new StringWriter();
             ContractClassWriter.CreateContractAssertions(writer, "", new[] {referencedDll}, new[] {referencingDll});
             Console.WriteLine(writer.ToString());
-            ClrAssemblyCompiler.CompileDlls(writer + new ContractClassWriter().UtilsSource, referenced);
+            ClrAssemblyCompiler.CompileDlls(writer + ContractClassWriter.UtilsSource, referenced);
             StringAssert.Contains("private void UsedByTestAssembly()", writer.ToString(),
                 "We should have created a method to contain the assertions for this assembly");
             return writer.ToString();

--- a/Tests/TestFramework/TestMethods.cs
+++ b/Tests/TestFramework/TestMethods.cs
@@ -17,7 +17,7 @@ namespace Tests.TestFramework
         {
             var (referencedDll, referencingDll) = ClrAssemblyCompiler.CompileDlls(referencing, referenced);
             using var writer = new StringWriter();
-            Program.CreateContractAssertions(writer, "", new[] {referencedDll}, new[] {referencingDll});
+            ContractClassWriter.CreateContractAssertions(writer, "", new[] {referencedDll}, new[] {referencingDll});
             Console.WriteLine(writer.ToString());
             ClrAssemblyCompiler.CompileDlls(writer + new ContractClassWriter().UtilsSource, referenced);
             StringAssert.Contains("private void UsedByTestAssembly()", writer.ToString(),
@@ -29,7 +29,7 @@ namespace Tests.TestFramework
         {
             var (referencedDll, referencingDll) = ClrAssemblyCompiler.CompileDlls(referencing, referenced);
             using var writer = new StringWriter();
-            Program.CreateContractAssertions(writer, "", new[] {referencedDll}, new[] {referencingDll});
+            ContractClassWriter.CreateContractAssertions(writer, "", new[] {referencedDll}, new[] {referencingDll});
             Console.WriteLine(writer.ToString());
             StringAssert.DoesNotContain("private void UsedByTestAssembly()", writer.ToString(),
                 "There shouldn't be a contract assertion");

--- a/Tests/TestFramework/TestMethods.cs
+++ b/Tests/TestFramework/TestMethods.cs
@@ -7,7 +7,13 @@ namespace Tests.TestFramework
 {
     abstract class TestMethods
     {
-        protected static void ContractAssertionShouldCompile(string referencing, string referenced)
+        /// <summary>
+        /// Generates a contract assertion and asserts that it compiles
+        /// </summary>
+        /// <param name="referencing">C# source for the referencing class(es)</param>
+        /// <param name="referenced">C# source for the referenced class(es)</param>
+        /// <returns>C# source for the contract assertion</returns>
+        protected static string ContractAssertionShouldCompile(string referencing, string referenced)
         {
             var (referencedDll, referencingDll) = ClrAssemblyCompiler.CompileDlls(referencing, referenced);
             using var writer = new StringWriter();
@@ -16,6 +22,7 @@ namespace Tests.TestFramework
             ClrAssemblyCompiler.CompileDlls(writer + new ContractClassWriter().UtilsSource, referenced);
             StringAssert.Contains("private void UsedByTestAssembly()", writer.ToString(),
                 "We should have created a method to contain the assertions for this assembly");
+            return writer.ToString();
         }
 
         protected static void ContractAssertionShouldBeEmpty(string referencing, string referenced)


### PR DESCRIPTION
### What problem is this feature intended to solve?

Sometimes a library has consumers that are slow to take updates.  The generated contract assertions don't compile, because the latest version of a consumer was built against an old version of the library, and there have been breaking changes since then.  At this point, regenerating the contract assertions will constantly revert the breaking change to the contract assertion, creating a compile error even though the team maintaining the consumer has been notified.

### What other approaches have been tried?

One option is to just ignore the affected consumer, which basically amounts to an ultimatum: take our breaking changes or we will stop caring about you.  I'm concerned that this creates a somewhat toxic cross-team relationship and want to find a better way.

A more fine-grained approach is to comment out the offending line(s) of code in the contract.  This fixes the build, but only until the contract is next regenerated.

### New approach

This PR attempts to preserve the commenting-out of contract code.  If you prefix a broken assertion with `//IGNORE ` then the next time NetDoc runs it should leave the commented-out line alone.  This should keep the build green.