### PR TITLE
Consider nested types in consumers

### DIFF
--- a/NetDoc/AssemblyAnalyser.cs
+++ b/NetDoc/AssemblyAnalyser.cs
@@ -22,7 +22,8 @@ namespace NetDoc
                 using var referencingAssembly = AssemblyDefinition.ReadAssembly(path, new ReaderParameters{AssemblyResolver = resolver});
 
                 var types = referencingAssembly.Modules
-                    .SelectMany(a => a.Types).ToHashSet();
+                    .SelectMany(a => a.Types)
+                    .SelectMany(FlattenNestedTypes).ToHashSet();
                 return types
                     .SelectMany(GetAllBodies)
                     .SelectMany(GetAllCalls)
@@ -35,6 +36,9 @@ namespace NetDoc
                 return new Call[0];
             }
         }
+
+        private IEnumerable<TypeDefinition> FlattenNestedTypes(TypeDefinition type) =>
+            new[] {type}.Concat(type.NestedTypes.SelectMany(FlattenNestedTypes));
 
         /// <summary>
         /// For nested classes, returns the outer class

--- a/Tests/NestedReferencedClassesTests.cs
+++ b/Tests/NestedReferencedClassesTests.cs
@@ -4,7 +4,7 @@ using Tests.TestFramework;
 namespace Tests
 {
     [TestFixture]
-    class NestedClassesTests : TestMethods
+    class NestedReferencedClassesTests : TestMethods
     {
         [Test]
         public void Constructor()

--- a/Tests/NestedReferencingClassesTests.cs
+++ b/Tests/NestedReferencingClassesTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using Tests.TestFramework;
+
+namespace Tests
+{
+    class NestedReferencingClassesTests : TestMethods
+    {
+        [Test]
+        public void ConsumerIsYieldReturnStateMachine()
+        {
+            var referenced = Class("public static int Foo() => 1;", "ReferencedClass");
+            var referencing = Class(@"System.Collections.Generic.IEnumerable<int> Bar() { yield return 1; yield return ReferencedClass.Foo(); }");
+
+            ContractAssertionShouldCompile(referencing, referenced);
+        }
+
+        [Test]
+        public void ConsumerHasNestedClass()
+        {
+            var referenced = Class("public static int Foo() => 1;", "ReferencedClass");
+            var referencing = Class(Class(@"int Bar() => ReferencedClass.Foo();", "NestedClass", null), "OuterClass");
+
+            ContractAssertionShouldCompile(referencing, referenced);
+        }
+    }
+}


### PR DESCRIPTION
Fix for the failure to catch https://github.com/red-gate/SQLCompareEngine/commit/3a7b8a15e3193443b7c134cda23cf1a4e04bff95 for which we thought there were no consumers.  We missed a usage because it was in a yield return method and it had to be fixed here: https://github.com/red-gate/SQLSourceControl/commit/5499d0f76d66d6db70838a76bb6ce7de6873f793