### PR TITLE
Remove duplicate reference

### DIFF
--- a/NetDoc/NetDoc.csproj
+++ b/NetDoc/NetDoc.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.1" />
-    <PackageReference Include="Microsoft.Net.Compilers" Version="3.6.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="1.0.0">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
Nukes a reference that is causing [this build](https://buildserver.red-gate.com/buildConfiguration/SqlCompareDataCompare_Engines_Extras_ContractAssertionsForEngineApi/17612512?showRootCauses=true&expandBuildChangesSection=true&expandBuildProblemsSection=true&showLog=17612512_222_163.164.222) to fail:
```
D:\BuildAgentB\work\38849153fccfa85b\NetDoc\NetDoc.csproj : error NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: Microsoft.Net.Compilers 3.6.0, Microsoft.Net.Compilers 3.6.0.
```