### PR TITLE
Implicit type arguments

### DIFF
--- a/NetDoc/Call.cs
+++ b/NetDoc/Call.cs
@@ -204,6 +204,11 @@ namespace NetDoc
                     return "object";
                 }
             }
+            
+            if (type is GenericParameter)
+            {
+                return "object";
+            }
 
             var nameSpace = type.Namespace;
 

--- a/Tests/GenericsTests.cs
+++ b/Tests/GenericsTests.cs
@@ -15,6 +15,14 @@ namespace Tests
         }
 
         [Test]
+        public void ImplicitTypeArgument()
+        {
+            var referenced = Class(@"public void Method<T>(T param) {}", "ReferencedClass");
+            var referencing = Class("public void Method() => new ReferencedClass().Method(2);");
+            ContractAssertionShouldCompile(referencing, referenced);
+        }
+
+        [Test]
         public void ParameterizedFactoryMethod()
         {
             var referenced = Class("public T Foo() => default;", "ReferencedClass<T>");


### PR DESCRIPTION
This PR fixes up assertions for methods of the form:
``` c#
void Foo<T>(T param) {}
```
NetDoc was outputting a call to `Foo<T>` which didn't compile because T is a type argument, not a class or interface. 

This PR does the bare minimum to make such assertions compile by returning `object` instead.

A more thorough approach would check for generic type constraints such as `where T : blah` but that isn't necessary in any code we currently use.