### PR TITLE
Support a generics edge case and single-parameter delegates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _ReSharper*/
 .vs/
 #Nuget packages folder
 packages/
+/.idea/

--- a/NetDoc/AssemblyAnalyser.cs
+++ b/NetDoc/AssemblyAnalyser.cs
@@ -59,6 +59,10 @@ namespace NetDoc
             if (definition?.Body == null) yield break;
             foreach (var instruction in definition.Body.Instructions.Where(IsCall).Where(x => !IsBaseClass(x, definition)))
             {
+                //if ((instruction.Operand as MemberReference)?.Name == "get_Obj1")
+                //{
+                //    Console.WriteLine("Badger: " + definition);
+                //}
                 yield return new Call(instruction, ReferencedDlls);
             }
         }

--- a/NetDoc/Call.cs
+++ b/NetDoc/Call.cs
@@ -78,13 +78,19 @@ namespace NetDoc
                 return AssignToRandomVariable(FieldReference.FieldType, $"{ClassOrInstance}.{FieldReference.Name}");
             }
 
-            var parameters =
-                string.Join(", ", Parameters(MethodReference!.Resolve()?.Parameters ?? MethodReference.Parameters));
+            var parameterDefs = MethodReference!.Resolve()?.Parameters ?? MethodReference.Parameters;
+            var parameters = string.Join(", ", Parameters(parameterDefs));
             var indexerParameters = string.Join(", ",
                 Parameters(MethodReference.Resolve()?.Parameters.SkipLast() ?? MethodReference.Parameters.SkipLast()));
 
             if (m_Operand.Name == ".ctor")
             {
+                if (parameterDefs.Select(x => x.Name).SequenceEqual(["object", "method"]))
+                {
+                    // not sure how to infer the delegate signature
+                    return AssignToRandomVariable(MethodReference.DeclaringType, "_ => default");
+                }
+                
                 return AssignToRandomVariable(MethodReference.DeclaringType, $"new {TypeWithGenerics}({parameters})");
             }
 

--- a/NetDoc/Call.cs
+++ b/NetDoc/Call.cs
@@ -198,6 +198,10 @@ namespace NetDoc
                 {
                     return GetTypeName(declaringTypeGenericArgument);
                 }
+                else if ((declaringTypeGenericArgument as GenericParameter)?.Constraints.FirstOrDefault() is {} constraint)
+                {
+                    return GetTypeName(constraint.ConstraintType);
+                }
                 else
                 {
                     // Avoid stack overflow

--- a/Tests/DelegatesTests.cs
+++ b/Tests/DelegatesTests.cs
@@ -1,0 +1,16 @@
+﻿using NUnit.Framework;
+using Tests.TestFramework;
+
+namespace Tests;
+
+[TestFixture]
+internal class DelegatesTests : TestMethods
+{
+    [Test]
+    public void Delegate()
+    {
+        var referenced = "public delegate bool MyDelegate(int i);";
+        var referencing = Class("MyDelegate MakeDelegate() => i => i > 3;", "ReferencingClass");
+        ContractAssertionShouldCompile(referencing, referenced);
+    }
+}

--- a/Tests/DelegatesTests.cs
+++ b/Tests/DelegatesTests.cs
@@ -7,10 +7,26 @@ namespace Tests;
 internal class DelegatesTests : TestMethods
 {
     [Test]
-    public void Delegate()
+    public void DelegateWithOneArgument()
     {
         var referenced = "public delegate bool MyDelegate(int i);";
         var referencing = Class("MyDelegate MakeDelegate() => i => i > 3;", "ReferencingClass");
+        ContractAssertionShouldCompile(referencing, referenced);
+    }
+
+    [Test, Ignore("Not sure how to infer the delegate's signature")]
+    public void DelegateWithTwoArguments()
+    {
+        var referenced = "public delegate bool MyDelegate(int i, int j);";
+        var referencing = Class("MyDelegate MakeDelegate() => (i, j) => i > j;", "ReferencingClass");
+        ContractAssertionShouldCompile(referencing, referenced);
+    }
+
+    [Test, Ignore("Not sure how to infer the delegate's signature")]
+    public void VoidDelegate()
+    {
+        var referenced = "public delegate void MyDelegate(int i);";
+        var referencing = Class("MyDelegate MakeDelegate() => i => {};", "ReferencingClass");
         ContractAssertionShouldCompile(referencing, referenced);
     }
 }

--- a/Tests/GenericsTests.cs
+++ b/Tests/GenericsTests.cs
@@ -40,11 +40,29 @@ namespace Tests
         }
 
         [Test]
-        public void TypeConstraint()
+        public void FrameworkTypeConstraint()
         {
             var referenced = Class("public void Foo(T param) {}", "ReferencedClass<T, U> where T : System.Collections.Generic.IEnumerable<U>");
             var referencing = Class("public void Bar(ReferencedClass<DerivedList, int> x) {x.Foo(new DerivedList());}", "ReferencingClass")
                 + Class("", "DerivedList : System.Collections.Generic.List<int>");
+            ContractAssertionShouldCompile(referencing, referenced);
+        }
+        
+        [Test]
+        public void ReferencedTypeConstraint2()
+        {
+            var referenced = Class("public T Obj1 => default;", "Mapping<T> where T : class, IMappedObject")
+                             + Class("", "IMappedObject", notAClass: "interface");
+            var referencing = Class("""
+                                    void HasCustomComparisonMappings<T>(System.Collections.Generic.IEnumerable<Mapping<T>> mappings)
+                                                where T : class, IMappedObject
+                                            {
+                                                foreach (var mapping in mappings)
+                                                {
+                                                    if (mapping.Obj1 != null) {}
+                                                }
+                                            }
+                                    """);
             ContractAssertionShouldCompile(referencing, referenced);
         }
 

--- a/Tests/GenericsTests.cs
+++ b/Tests/GenericsTests.cs
@@ -51,11 +51,9 @@ namespace Tests
         [Test]
         public void ReferencedTypeConstraint2()
         {
-            var referenced = Class("public T Obj1 => default;", "Mapping<T> where T : class, IMappedObject")
-                             + Class("", "IMappedObject", notAClass: "interface");
-            var referencing = Class("""
-                                    string Blah<T>(Mapping<T> mapping) where T : class, IMappedObject => mapping.Obj1.ToString();
-                                    """);
+            var referenced = Class("public T Obj1() => default;", "Mapping<T> where T : MappedObject")
+                             + Class("", "MappedObject");
+            var referencing = Class("void Blah<T>(Mapping<T> mapping) where T : MappedObject => mapping.Obj1();");
             ContractAssertionShouldCompile(referencing, referenced);
         }
 

--- a/Tests/GenericsTests.cs
+++ b/Tests/GenericsTests.cs
@@ -54,14 +54,7 @@ namespace Tests
             var referenced = Class("public T Obj1 => default;", "Mapping<T> where T : class, IMappedObject")
                              + Class("", "IMappedObject", notAClass: "interface");
             var referencing = Class("""
-                                    void HasCustomComparisonMappings<T>(System.Collections.Generic.IEnumerable<Mapping<T>> mappings)
-                                                where T : class, IMappedObject
-                                            {
-                                                foreach (var mapping in mappings)
-                                                {
-                                                    if (mapping.Obj1 != null) {}
-                                                }
-                                            }
+                                    string Blah<T>(Mapping<T> mapping) where T : class, IMappedObject => mapping.Obj1.ToString();
                                     """);
             ContractAssertionShouldCompile(referencing, referenced);
         }

--- a/Tests/GenericsTests.cs
+++ b/Tests/GenericsTests.cs
@@ -40,7 +40,7 @@ namespace Tests
         }
 
         [Test]
-        public void FrameworkTypeConstraint()
+        public void TypeConstraint()
         {
             var referenced = Class("public void Foo(T param) {}", "ReferencedClass<T, U> where T : System.Collections.Generic.IEnumerable<U>");
             var referencing = Class("public void Bar(ReferencedClass<DerivedList, int> x) {x.Foo(new DerivedList());}", "ReferencingClass")
@@ -49,11 +49,10 @@ namespace Tests
         }
         
         [Test]
-        public void ReferencedTypeConstraint2()
+        public void TypeConstraintAlsoInReferencingMethod()
         {
-            var referenced = Class("public T Obj1() => default;", "Mapping<T> where T : MappedObject")
-                             + Class("", "MappedObject");
-            var referencing = Class("void Blah<T>(Mapping<T> mapping) where T : MappedObject => mapping.Obj1();");
+            var referenced = Class("public T Foo() => default;", "ReferencedClass<T> where T : System.IDisposable");
+            var referencing = Class("void Blah<T>(ReferencedClass<T> x) where T : System.IDisposable => x.Foo();");
             ContractAssertionShouldCompile(referencing, referenced);
         }
 

--- a/Tests/TestFramework/ClrAssemblyCompiler.cs
+++ b/Tests/TestFramework/ClrAssemblyCompiler.cs
@@ -161,7 +161,7 @@ using System.Reflection;
                 {
                     Console.WriteLine(stdout);
                 }
-                Assert.That(exitCode, Is.Zero, "Failed to compile CLR assembly (exit code non-zero)");
+                Assert.That(exitCode, Is.Zero, "Failed to compile CLR assembly (exit code non-zero). Source code:\n{0}", sourceCode);
             }
 
             return outputDll;

--- a/Tests/TestFramework/TestMethods.cs
+++ b/Tests/TestFramework/TestMethods.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 
 namespace Tests.TestFramework
 {
-    abstract class TestMethods
+    class TestMethods
     {
         /// <summary>
         /// Generates a contract assertion and asserts that it compiles

--- a/Tests/TestFramework/TestMethods.cs
+++ b/Tests/TestFramework/TestMethods.cs
@@ -36,12 +36,14 @@ namespace Tests.TestFramework
         }
 
         [TestCase("int x;", "Class2", null, ExpectedResult = "public class Class2 {int x;}")]
+        [TestCase("", "INterface2", null, "interface", ExpectedResult = "public interface INterface2 {}")]
         [TestCase("int x;", "Class2", "ns", ExpectedResult = "namespace ns {public class Class2 {int x;}}")]
-        public static string Class(string contents, string className = "Class1", string? ns = "Name.Space")
+        public static string Class(string contents, string className = "Class1", string? ns = "Name.Space",
+            string notAClass = "class")
         {
             return string.IsNullOrEmpty(ns)
-                ? $"public class {className} {{{contents}}}"
-                : $"namespace {ns} {{{Class(contents, className, null)}}}";
+                ? $"public {notAClass} {className} {{{contents}}}"
+                : $"namespace {ns} {{{Class(contents, className, null, notAClass)}}}";
         }
 
         [TearDown]


### PR DESCRIPTION
Our engine now has even more consumers, so here's support for:

### Another generics case
When both the consuming method and the consumed class have the same constrained generic parameter, NetDoc was failing to find the type constraint and defaulting to `object`. This PR fixes that limitation.

### Very basic delegate support
Delegate constructors are weird. The C# looks fairly straightforward:

``` c#
public delegate bool MyDelegate(int i);
MyDelegate MakeDelegate() => i => i > 3;
```

However the IL uses a hidden constructor that takes an `object` (the instance, or null for static methods) and an `IntPtr` to the method you want to call on that object. This can't be directly called in C# because magic. Figuring out the parameters seems to be hard, so for now we'll just output a best guess of `_ => default`. This has several shortcomings:
 - It will break for `void` delegates (see ignored test)
 - It will break for numbers of params other than 1 (see ignored test)