### PR TITLE
Support for delegates with different method signatures

### DIFF
--- a/NetDoc/Call.cs
+++ b/NetDoc/Call.cs
@@ -10,13 +10,20 @@ namespace NetDoc
     public class Call
     {
         private readonly MemberReference m_Operand;
+        private readonly MethodReference? m_Delegate;
         private IEnumerable<string> ReferencedDlls { get; }
 
         public Call(Instruction instruction, IEnumerable<string> referencedDlls)
         {
             ReferencedDlls = referencedDlls;
             m_Operand = (MemberReference) instruction.Operand;
-            if (instruction.OpCode == OpCodes.Ldfld || instruction.OpCode == OpCodes.Stfld)
+            if (instruction.OpCode == OpCodes.Newobj &&
+                MethodReference?.Parameters.Select(x => x.ParameterType.Name).SequenceEqual([nameof(Object), nameof(IntPtr)]) == true &&
+                instruction.Previous.OpCode == OpCodes.Ldftn)
+            {
+                m_Delegate = (MethodReference)instruction.Previous.Operand;
+            }
+            else if (instruction.OpCode == OpCodes.Ldfld || instruction.OpCode == OpCodes.Stfld)
             {
                 IsStatic = false;
             }

--- a/NetDoc/Call.cs
+++ b/NetDoc/Call.cs
@@ -92,10 +92,13 @@ namespace NetDoc
 
             if (m_Operand.Name == ".ctor")
             {
-                if (parameterDefs.Select(x => x.Name).SequenceEqual(["object", "method"]))
+                if (m_Delegate != null)
                 {
-                    // not sure how to infer the delegate signature
-                    return AssignToRandomVariable(MethodReference.DeclaringType, "_ => default");
+                    var args = string.Join(", ", m_Delegate.Parameters.Select((p, i) => $"{GetTypeName(p.ParameterType)} arg{i}"));
+                    var expression = m_Delegate.ReturnType.FullName == "System.Void"
+                        ? "{}"
+                        : CallToFactory(m_Delegate.ReturnType);
+                    return AssignToRandomVariable(MethodReference.DeclaringType, $"({args}) => {expression}");
                 }
                 
                 return AssignToRandomVariable(MethodReference.DeclaringType, $"new {TypeWithGenerics}({parameters})");

--- a/Tests/DelegatesTests.cs
+++ b/Tests/DelegatesTests.cs
@@ -14,7 +14,7 @@ internal class DelegatesTests : TestMethods
         ContractAssertionShouldCompile(referencing, referenced);
     }
 
-    [Test, Ignore("Not sure how to infer the delegate's signature")]
+    [Test]
     public void DelegateWithTwoArguments()
     {
         var referenced = "public delegate bool MyDelegate(int i, int j);";
@@ -22,7 +22,7 @@ internal class DelegatesTests : TestMethods
         ContractAssertionShouldCompile(referencing, referenced);
     }
 
-    [Test, Ignore("Not sure how to infer the delegate's signature")]
+    [Test]
     public void VoidDelegate()
     {
         var referenced = "public delegate void MyDelegate(int i);";

--- a/Tests/DelegatesTests.cs
+++ b/Tests/DelegatesTests.cs
@@ -29,4 +29,12 @@ internal class DelegatesTests : TestMethods
         var referencing = Class("MyDelegate MakeDelegate() => i => {};", "ReferencingClass");
         ContractAssertionShouldCompile(referencing, referenced);
     }
+    
+    [Test]
+    public void ReusedDelegate()
+    {
+        var referenced = "public delegate bool MyDelegate(int i);";
+        var referencing = Class("MyDelegate[] MakeDelegates() => new MyDelegate[] {Foo, Foo}; bool Foo(int i) => i > 3;", "ReferencingClass");
+        ContractAssertionShouldCompile(referencing, referenced);
+    }
 }

--- a/Tests/DelegatesTests.cs
+++ b/Tests/DelegatesTests.cs
@@ -10,7 +10,7 @@ internal class DelegatesTests : TestMethods
     public void DelegateWithOneArgument()
     {
         var referenced = "public delegate bool MyDelegate(int i);";
-        var referencing = Class("MyDelegate MakeDelegate() => i => i > 3;", "ReferencingClass");
+        var referencing = Class("MyDelegate MakeDelegate() => Foo; bool Foo(int i) => i > 3;", "ReferencingClass");
         ContractAssertionShouldCompile(referencing, referenced);
     }
 

--- a/Tests/TestFramework/ClrAssemblyCompiler.cs
+++ b/Tests/TestFramework/ClrAssemblyCompiler.cs
@@ -47,8 +47,8 @@ namespace Tests.TestFramework
             var packageDir = new DirectoryInfo(Path.Combine(PackagesFolder, "microsoft.netframework.referenceassemblies." + moniker));
             Assert.That(packageDir.Exists, $"Directory {packageDir.FullName} does not exist");
             var versions = packageDir.GetDirectories();
-            Assert.That(versions.Length, Is.EqualTo(1), $"Directory {packageDir.FullName} does not contain exactly one version");
-            var referenceDir = new DirectoryInfo(Path.Combine(versions.Single().FullName, "build", ".NETFramework", version));
+            Assert.That(versions.Length, Is.GreaterThanOrEqualTo(1), $"Directory {packageDir.FullName} does not contain exactly one version");
+            var referenceDir = new DirectoryInfo(Path.Combine(versions.First().FullName, "build", ".NETFramework", version));
             Assert.That(referenceDir.Exists, $"Directory {referenceDir.FullName} does not exist");
 
             return referenceDir.FullName;


### PR DESCRIPTION
#### Context
#11 added basic support for delegates by detecting calls to the special constructor they use, and hardcoding `_ => default` which works for any non-void signature with 1 parameter.

It works for what we need (currently there's only 1 delegate consumed across our code), but it would be nice to support all delegate signatures and to assert that the signature is still correct.

#### Approach
My approach to this PR was to run the [DelegateWithOneArgument](https://github.com/samblackburn/NetDoc/blob/main/Tests/DelegatesTests.cs) test, put a breakpoint in [AssemblyAnalyzer](https://github.com/samblackburn/NetDoc/blob/main/NetDoc/AssemblyAnalyser.cs#L59) and dump the opcodes for the method.

```c#
MyDelegate MakeDelegate() => Foo;
bool Foo(int i) => i > 3;
```

```
IL_0000: ldarg.0
IL_0001: ldftn System.Boolean Name.Space.ReferencingClass::Foo(System.Int32)
IL_0007: newobj System.Void MyDelegate::.ctor(System.Object,System.IntPtr)
IL_000c: ret
```

We can see that the instruction before the call to the constructor is loading a pointer to the function whose signature we care about.

#### Risks
This will break if the function pointer isn't loaded immediately before the constructor is called. To be honest I have no idea if this is likely to happen, but I've not found a way to make it happen yet.

#### Related reading
https://www.codeproject.com/articles/Dynamic-Runtime-Delegates-Conversion