### PR TITLE
Substitute method-level generic parameters in GetTypeName

### DIFF
--- a/NetDoc/Call.cs
+++ b/NetDoc/Call.cs
@@ -180,26 +180,34 @@ namespace NetDoc
             return name;
         }
 
-        private string GetTypeName(TypeReference type, GenericInstanceType? declaringType = null)
+        private string GetTypeName(TypeReference type, GenericInstanceType? declaringType = null, GenericInstanceMethod? methodContext = null)
         {
+            declaringType ??= DeclaringType as GenericInstanceType;
+            methodContext ??= MethodReference as GenericInstanceMethod;
+
             if (type is TypeDefinition def && !CanSeeFromAssertion(type) && CanSeeFromAssertion(def.BaseType))
             {
-                return GetTypeName(def.BaseType);
+                return GetTypeName(def.BaseType, declaringType, methodContext);
             }
 
-            declaringType ??= DeclaringType as GenericInstanceType;
             if (type.Name.StartsWith("!"))
             {
+                var isMethodParameter = type.Name.StartsWith("!!");
                 var genericParamNumber = int.Parse(type.Name.TrimStart('!'));
-                if (declaringType != null)
+                if (isMethodParameter && methodContext != null)
+                {
+                    type = methodContext.GenericArguments[genericParamNumber];
+                }
+                else if (!isMethodParameter && declaringType != null)
                 {
                     type = declaringType.GenericArguments[genericParamNumber];
-                    if (!CanSeeFromAssertion(type))
-                    {
-                        return "object";
-                    }
                 }
                 else
+                {
+                    return "object";
+                }
+
+                if (!CanSeeFromAssertion(type))
                 {
                     return "object";
                 }
@@ -207,26 +215,30 @@ namespace NetDoc
 
             var className = type.Name.Split('`')[0];
 
-            if (type is GenericParameter ofT && declaringType != null)
+            if (type is GenericParameter ofT)
             {
-                var declaringTypeGenericArgument = declaringType.GenericArguments[ofT.Position];
-                if (declaringTypeGenericArgument != type)
+                if (ofT.Type == GenericParameterType.Method && methodContext != null)
                 {
-                    return GetTypeName(declaringTypeGenericArgument);
+                    var methodGenericArgument = methodContext.GenericArguments[ofT.Position];
+                    if (methodGenericArgument != type && CanSeeFromAssertion(methodGenericArgument))
+                    {
+                        return GetTypeName(methodGenericArgument, declaringType, methodContext);
+                    }
                 }
-                else if ((declaringTypeGenericArgument as GenericParameter)?.Constraints.FirstOrDefault() is {} constraint)
+                else if (declaringType != null)
                 {
-                    return GetTypeName(constraint.ConstraintType);
+                    var declaringTypeGenericArgument = declaringType.GenericArguments[ofT.Position];
+                    if (declaringTypeGenericArgument != type)
+                    {
+                        return GetTypeName(declaringTypeGenericArgument, declaringType, methodContext);
+                    }
+                    else if ((declaringTypeGenericArgument as GenericParameter)?.Constraints.FirstOrDefault() is {} constraint)
+                    {
+                        return GetTypeName(constraint.ConstraintType, declaringType, methodContext);
+                    }
                 }
-                else
-                {
-                    // Avoid stack overflow
-                    return "object";
-                }
-            }
-            
-            if (type is GenericParameter)
-            {
+
+                // Avoid stack overflow
                 return "object";
             }
 
@@ -234,11 +246,11 @@ namespace NetDoc
 
             if (type.DeclaringType != null)
             {
-                nameSpace = GetTypeName(type.DeclaringType);
+                nameSpace = GetTypeName(type.DeclaringType, declaringType, methodContext);
             }
 
             var generics = type is GenericInstanceType git
-                ? $"<{String.Join(", ", git.GenericArguments.Select(x => GetTypeName(x)))}>"
+                ? $"<{String.Join(", ", git.GenericArguments.Select(x => GetTypeName(x, declaringType, methodContext)))}>"
                 : "";
             if (!string.IsNullOrEmpty(nameSpace)) nameSpace += ".";
             var fullName = $"{nameSpace}{className}{generics}".TrimEnd('&');

--- a/Tests/GenericsTests.cs
+++ b/Tests/GenericsTests.cs
@@ -63,5 +63,14 @@ namespace Tests
             var referencing = Class("public void Method(ReferencedClass<T> x) => x.Method();", "ReferencingClass<T>");
             ContractAssertionShouldCompile(referencing, referenced);
         }
+
+        [Test]
+        public void GenericParameterNestedInsideFuncParameter()
+        {
+            var referenced = Class("public static string GetOptionsPayload<T>(System.Func<T, bool> predicate) => default;", "ReferencedClass")
+                              + Class("", "OnlyInReferenced", "Name.Space", "struct");
+            var referencing = Class("public static void Bar() { ReferencedClass.GetOptionsPayload<OnlyInReferenced>(x => true); }", "ReferencingClass");
+            ContractAssertionShouldCompile(referencing, referenced);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `GetTypeName` only had a substitution map for the enclosing *type's* generic arguments (`declaringType`). A generic method's own type parameter `T` resolved correctly when it appeared as the explicit `<T>` on a call, but fell back to `object` whenever it appeared nested inside another generic parameter type, e.g. `Func<T, bool>`.
- This caused red-gate/OracleTools#3836 to generate `Create<System.Func<object, bool>>()` for a call to `GetOptionsPayload<Option>(Func<Option, bool>)`, which fails to compile with CS1503 because `Option` is a value type (delegate contravariance masks the bug for reference types).
- Added a `methodContext: GenericInstanceMethod?` alongside `declaringType`, resolving method-owned `GenericParameter`s (`ofT.Type == GenericParameterType.Method`) against the call site's actual generic arguments, and threaded it through the existing recursive calls. Also fixed the analogous `"!!"` vs `"!"` synthetic-name case, which had the same type-vs-method blind spot.

## Test plan
- [x] Added `GenericParameterNestedInsideFuncParameter` to `Tests/GenericsTests.cs`, reproducing the exact CS1503 shape from the PR comment; it fails on `main` and passes with this fix.
- [x] Full suite: 49/49 passing (`dotnet test`).